### PR TITLE
Updating live feeds to use one from Sen and one from NASA

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -113,7 +113,12 @@ export const NavBar: React.FC = () => {
     setIsUserSettingsOpen,
   } = useAppContext();
   const {
-    settings: { reduceMotion, animationSpeedAdjustment, reduceTransparency },
+    settings: {
+      reduceMotion,
+      enableLoadingAnimation,
+      animationSpeedAdjustment,
+      reduceTransparency,
+    },
   } = useSettingsContext();
 
   const closeAllModals = () => {
@@ -121,6 +126,11 @@ export const NavBar: React.FC = () => {
     setIsContactFormOpen(false);
     setIsUserSettingsOpen(false);
   };
+
+  const isLoadingAnimationDisabled = useMemo(
+    () => !enableLoadingAnimation || reduceMotion,
+    [enableLoadingAnimation, reduceMotion],
+  );
 
   // get current viewport width
   const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
@@ -141,13 +151,13 @@ export const NavBar: React.FC = () => {
     if (viewportWidth < 540) {
       return 0;
     }
-    return reduceMotion ? 0 : 500 * animationSpeedAdjustment;
+    return isLoadingAnimationDisabled ? 0 : 500 * animationSpeedAdjustment;
   }, [viewportWidth]);
 
   return (
     <nav
       className={navBarCss(
-        reduceMotion,
+        isLoadingAnimationDisabled,
         animationSpeedAdjustment,
         reduceTransparency,
       )}
@@ -171,7 +181,7 @@ export const NavBar: React.FC = () => {
         </span>
         <NavButtonContainer
           animationSpeedAdjustment={animationSpeedAdjustment}
-          reduceMotion={reduceMotion}
+          reduceMotion={isLoadingAnimationDisabled}
           showNavDelayMs={showNavDelayMs}
         >
           <Button

--- a/src/components/base/FadeFromBlack.tsx
+++ b/src/components/base/FadeFromBlack.tsx
@@ -35,7 +35,11 @@ const fadeInFromBlackCss = (
 export const FadeFromBlack = ({ children }: React.PropsWithChildren) => {
   const { navAnimationSeconds } = useAppContext();
   const {
-    settings: { reduceMotion, animationSpeedAdjustment },
+    settings: {
+      reduceMotion,
+      enableLoadingAnimation,
+      animationSpeedAdjustment,
+    },
   } = useSettingsContext();
   const { animationDurationSeconds, animationDelaySeconds } = usePanelContext();
   const [isLoading, setIsLoading] = useState(true);
@@ -46,6 +50,11 @@ export const FadeFromBlack = ({ children }: React.PropsWithChildren) => {
       (animationDurationSeconds ?? 4.5) + (animationDelaySeconds ?? 0) + 0.55
     );
   }, [animationDurationSeconds, animationDelaySeconds, navAnimationSeconds]);
+
+  const isLoadingAnimationDisabled = useMemo(
+    () => !enableLoadingAnimation || reduceMotion,
+    [enableLoadingAnimation, reduceMotion],
+  );
 
   const timeToFadeIn = useMemo(() => {
     return (
@@ -68,7 +77,7 @@ export const FadeFromBlack = ({ children }: React.PropsWithChildren) => {
       () => {
         setIsFadedIn(true);
       },
-      reduceMotion ? 0 : timeToFadeIn,
+      isLoadingAnimationDisabled ? 0 : timeToFadeIn,
     );
   }, [isLoading]);
 
@@ -77,7 +86,7 @@ export const FadeFromBlack = ({ children }: React.PropsWithChildren) => {
       className={fadeInFromBlackCss(
         isLoading,
         delayedAnimationSeconds * animationSpeedAdjustment,
-        reduceMotion,
+        isLoadingAnimationDisabled,
         isFadedIn,
       )}
     >

--- a/src/components/base/Panel.tsx
+++ b/src/components/base/Panel.tsx
@@ -10,6 +10,7 @@ import { IconLayoutGrid, IconRefresh } from '@tabler/icons-react';
 const panelWrapperCss = (
   animationDuration: number,
   reduceMotion: boolean,
+  isLoadingAnimationDisabled: boolean,
   speedAdjustment: number,
   reduceTransparency: boolean,
 ) => css`
@@ -17,22 +18,22 @@ const panelWrapperCss = (
   --panel-menu--background-opacity: ${reduceTransparency ? 1 : 0.9} !important;
 
   &::before {
-    --panel-wrapper--before--transition-duration: ${reduceMotion
+    --panel-wrapper--before--transition-duration: ${isLoadingAnimationDisabled
       ? 0
       : animationDuration * speedAdjustment}s !important;
   }
 
   .panel {
-    --panel--transition-duration: ${reduceMotion
+    --panel--transition-duration: ${isLoadingAnimationDisabled
       ? 0
       : animationDuration * speedAdjustment}s !important;
   }
 
   .panel-body {
-    --panel-body--transition-duration: ${reduceMotion
+    --panel-body--transition-duration: ${isLoadingAnimationDisabled
       ? 0
       : animationDuration * 2 * speedAdjustment}s !important;
-    --panel-body--transition-delay: ${reduceMotion
+    --panel-body--transition-delay: ${isLoadingAnimationDisabled
       ? 0
       : 0.45 * speedAdjustment}s !important;
   }
@@ -112,7 +113,12 @@ export const InnerPanel = ({
   const [showPanel, setShowPanel] = useState<boolean>(false);
   const { navAnimationSeconds, allPanelsLoaded } = useAppContext();
   const {
-    settings: { reduceMotion, animationSpeedAdjustment, reduceTransparency },
+    settings: {
+      reduceMotion,
+      enableLoadingAnimation,
+      animationSpeedAdjustment,
+      reduceTransparency,
+    },
   } = useSettingsContext();
   const {
     animationDurationSeconds,
@@ -128,6 +134,11 @@ export const InnerPanel = ({
       return navAnimationSeconds + animationDelay + index * 0.04;
     }
   }, [allPanelsLoaded, animationDelay, index, navAnimationSeconds]);
+
+  const isLoadingAnimationDisabled = useMemo(
+    () => !enableLoadingAnimation || reduceMotion,
+    [enableLoadingAnimation, reduceMotion],
+  );
 
   const panelMenuChild = useMemo(() => {
     const panelMenu = React.Children.toArray(children).filter(
@@ -167,16 +178,16 @@ export const InnerPanel = ({
           () => {
             setShowPanel(true);
           },
-          reduceMotion ? 0 : 350 * animationSpeedAdjustment,
+          isLoadingAnimationDisabled ? 0 : 350 * animationSpeedAdjustment,
         );
       },
-      reduceMotion
+      isLoadingAnimationDisabled
         ? 0
         : delayedAnimationSeconds * 1000 * animationSpeedAdjustment,
     );
     return () => clearTimeout(timer);
   }, [
-    reduceMotion,
+    isLoadingAnimationDisabled,
     animationDuration,
     delayedAnimationSeconds,
     setAnimationDurationSeconds,
@@ -201,6 +212,7 @@ export const InnerPanel = ({
             panelWrapperCss(
               animationDurationSeconds ?? animationDuration,
               reduceMotion,
+              isLoadingAnimationDisabled,
               animationSpeedAdjustment,
               reduceTransparency,
             ),
@@ -260,7 +272,11 @@ export const PanelActions = ({
 }: React.PropsWithChildren<PanelActionsProps>) => {
   const updatedChildren: React.ReactNode[] = [];
   const {
-    settings: { reduceMotion, animationSpeedAdjustment },
+    settings: {
+      reduceMotion,
+      enableLoadingAnimation,
+      animationSpeedAdjustment,
+    },
   } = useSettingsContext();
   const {
     isPanelMenuOpen,
@@ -269,6 +285,11 @@ export const PanelActions = ({
     animationDelaySeconds,
   } = usePanelContext();
   const [spinIcon, setSpinIcon] = useState<boolean>(false);
+
+  const isLoadingAnimationDisabled = useMemo(
+    () => !enableLoadingAnimation || reduceMotion,
+    [enableLoadingAnimation, reduceMotion],
+  );
 
   // Child must be a Button
   React.Children.forEach(children, (child) => {
@@ -302,7 +323,7 @@ export const PanelActions = ({
         panelActionsCss(
           animationDurationSeconds ?? 0,
           animationDelaySeconds ?? 0,
-          reduceMotion,
+          isLoadingAnimationDisabled,
           animationSpeedAdjustment,
         ),
       )}
@@ -313,7 +334,7 @@ export const PanelActions = ({
           panelActionsCss(
             animationDurationSeconds ?? 0,
             animationDelaySeconds ?? 0,
-            reduceMotion,
+            isLoadingAnimationDisabled,
             animationSpeedAdjustment,
           ),
         )}

--- a/src/components/base/Toggle.tsx
+++ b/src/components/base/Toggle.tsx
@@ -73,7 +73,12 @@ export const Toggle: React.FC<ToggleProps> = ({
         toggleSwitchCss(reduceMotion, width, justifyContent),
       )}
     >
-      <span className="toggle-label">{label}</span>
+      {label && (
+        <>
+          <span className="toggle-label">{label}</span>
+          <span className="toggle-label-divider"></span>
+        </>
+      )}
       <span>
         <input
           aria-label={ariaLabel}

--- a/src/components/modals/UserSettings/UserSettings.tsx
+++ b/src/components/modals/UserSettings/UserSettings.tsx
@@ -41,11 +41,12 @@ const animationSpeedAdjustmentSelectCss = css`
   box-sizing: content-box;
   color: #fff;
   cursor: pointer;
-  font-size: 0.9rem;
-  height: 20px;
-  padding: 0 7px;
+  font-size: 0.75rem;
+  height: 24px;
+  padding: 0 2.5px;
   text-align: center;
-  width: 45px;
+  text-align-last: center;
+  width: 40px;
 
   @media (hover: hover) {
     &:hover {
@@ -58,6 +59,26 @@ const animationSpeedAdjustmentSelectCss = css`
   }
 `;
 
+const animationSpeedAdjustmentSelectLabelDividerCss = css`
+  flex-grow: 1;
+  height: 1px;
+  position: relative;
+
+  &::after {
+    background: hsl(
+      var(--base-blue-hue),
+      var(--base-blue-saturation),
+      calc(var(--base-blue-lightness) - 5%)
+    );
+    bottom: 0;
+    content: '';
+    height: 1px;
+    left: 0;
+    position: absolute;
+    right: 0;
+  }
+`;
+
 export const UserSettings: React.FC = () => {
   const { isUserSettingsOpen, setIsUserSettingsOpen } = useAppContext();
   const {
@@ -65,6 +86,7 @@ export const UserSettings: React.FC = () => {
       reduceMotion,
       reduceTransparency,
       reduceButtonAnimation,
+      enableLoadingAnimation,
       enableButtonAnimationAlways,
       disableButtonTooltips,
       lastUpdated,
@@ -108,7 +130,11 @@ export const UserSettings: React.FC = () => {
         ref={modalContentWrapperRef}
       >
         {/* Start toggle wrapper */}
-        <FlexWrapper gap={50} style={{ maxWidth: '440px', minWidth: '265px' }}>
+        <FlexWrapper
+          gap={50}
+          style={{ maxWidth: '440px', minWidth: '265px' }}
+          className="settings-toggles-wrapper"
+        >
           <FlexWrapper gap={28}>
             <h2 className={settingsSectionHeaderCss}>
               {'Motion & Accessibility'}
@@ -146,10 +172,29 @@ export const UserSettings: React.FC = () => {
                 checked={reduceMotion}
                 onChange={() => updateSettings({ reduceMotion: !reduceMotion })}
               />
+              <Toggle
+                label={
+                  <>
+                    {'Dashboard loading animation'}
+                    <TooltipWrapper
+                      title="Toggle the loading animation of the dashboard panels on page load"
+                      delay={300}
+                    >
+                      <IconInfoCircle color="#CCC" size={20} />
+                    </TooltipWrapper>
+                  </>
+                }
+                checked={enableLoadingAnimation}
+                onChange={() =>
+                  updateSettings({
+                    enableLoadingAnimation: !enableLoadingAnimation,
+                  })
+                }
+              />
               <FlexWrapper
                 alignItems="center"
                 flexDirection="row"
-                marginBottom={3}
+                justifyContent="space-between"
               >
                 <label>{'Animation speed adjustment: '}</label>
                 <TooltipWrapper
@@ -158,6 +203,9 @@ export const UserSettings: React.FC = () => {
                 >
                   <IconInfoCircle color="#CCC" size={20} />
                 </TooltipWrapper>
+                <span
+                  className={animationSpeedAdjustmentSelectLabelDividerCss}
+                ></span>
                 <select
                   className={animationSpeedAdjustmentSelectCss}
                   onChange={(e) =>

--- a/src/components/panels/IssFeed1.tsx
+++ b/src/components/panels/IssFeed1.tsx
@@ -15,16 +15,25 @@ export const IssFeed1: React.FC<Pick<PanelProps, 'index' | 'componentKey'>> = ({
       componentKey={componentKey}
       feedName="IssFeed1"
       menuContent={
-        <p>
-          {'Credit: '}
-          <a
-            href={`https://www.youtube-nocookie.com/watch?v=${issLiveFeedVideoId1}`}
-            target="_blank"
-            rel="noreferrer"
-          >
-            {'Live Video from the International Space Station'}
-          </a>
-        </p>
+        <>
+          <p>
+            {'Credit: '}
+            <a
+              href={`https://www.youtube.com/watch?v=${issLiveFeedVideoId1}`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {'Livestream of Earth & Space'}
+            </a>
+          </p>
+          <p>
+            {'Watch Earth Live from space in 4K, provided by '}
+            <a href="https://www.sen.com/" target="_blank" rel="noreferrer">
+              {'Sen'}
+            </a>
+            .
+          </p>
+        </>
       }
     />
   );

--- a/src/components/panels/IssFeed2.tsx
+++ b/src/components/panels/IssFeed2.tsx
@@ -19,25 +19,18 @@ export const IssFeed2: React.FC<Pick<PanelProps, 'index' | 'componentKey'>> = ({
           <p>
             {'Credit: '}
             <a
-              href={`https://www.youtube-nocookie.com/watch?v=${issLiveFeedVideoId2}`}
+              href={`https://www.youtube.com/watch?v=${issLiveFeedVideoId2}`}
               target="_blank"
               rel="noreferrer"
+              title="Live Video from the International Space Station (Official NASA Stream)"
             >
-              {'Live HD Views from the ISS'}
+              {'Live Video from the International Space Station'}
             </a>
           </p>
           <p>
             {
-              'More information for the ISS HD Earth Viewing Experiment can be found here: '
+              'Watch live video from the International Space Station, including inside views when the crew aboard the space station is on duty, provided by NASA.'
             }
-            <br />
-            <a
-              href="https://eol.jsc.nasa.gov/ESRS/HDEV/"
-              target="_blank"
-              rel="noreferrer"
-            >
-              {'NASA High Definition Earth-Viewing System'}
-            </a>
           </p>
         </>
       }

--- a/src/css/toggle.css
+++ b/src/css/toggle.css
@@ -7,6 +7,10 @@
   display: flex;
   position: relative;
 
+  .settings-toggles-wrapper & {
+    width: 100%;
+  }
+
   input:focus-visible ~ .switch .slider {
     outline: 0;
     box-shadow: 0 0 0px 3px rgba(71, 152, 216, 0.8);
@@ -67,6 +71,27 @@
     align-items: center;
     display: flex;
     gap: 8px;
+    /* max-width: 70%; */
+  }
+
+  .toggle-label-divider {
+    flex-grow: 1;
+    height: 1px;
+    position: relative;
+
+    &::after {
+      background: hsl(
+        var(--base-blue-hue),
+        var(--base-blue-saturation),
+        calc(var(--base-blue-lightness) - 5%)
+      );
+      bottom: 0;
+      content: '';
+      height: 1px;
+      left: 0;
+      position: absolute;
+      right: 0;
+    }
   }
 
   .switch {

--- a/src/providers/AppProvider.tsx
+++ b/src/providers/AppProvider.tsx
@@ -42,8 +42,8 @@ const AppProvider = ({ children }: React.PropsWithChildren) => {
       setIsContactFormOpen,
       isUserSettingsOpen,
       setIsUserSettingsOpen,
-      issLiveFeedVideoId1: 'idAoaC5DmFI',
-      issLiveFeedVideoId2: 'c5ZJ-5mP3_Y',
+      issLiveFeedVideoId1: 'fO9e9jnhYK8',
+      issLiveFeedVideoId2: 'idAoaC5DmFI',
     }),
     [
       navAnimationSeconds,

--- a/src/providers/SettingsProvider.tsx
+++ b/src/providers/SettingsProvider.tsx
@@ -20,6 +20,7 @@ export interface Settings {
   reduceMotion: boolean;
   reduceTransparency: boolean;
   reduceButtonAnimation: boolean;
+  enableLoadingAnimation: boolean;
   enableButtonAnimationAlways: boolean;
   animationSpeedAdjustment: number;
   disableButtonTooltips: boolean;
@@ -35,6 +36,7 @@ const SettingsProvider = ({ children }: { children: React.ReactNode }) => {
     reduceMotion: false,
     reduceTransparency: false,
     reduceButtonAnimation: false,
+    enableLoadingAnimation: false,
     enableButtonAnimationAlways: false,
     animationSpeedAdjustment: 1,
     disableButtonTooltips: false,

--- a/src/shared/PanelConfigs.ts
+++ b/src/shared/PanelConfigs.ts
@@ -86,16 +86,16 @@ export type PanelConfig = BasePanelConfig &
 
 export const defaultPanelConfigs: Record<AvailablePanels, PanelConfig> = {
   IssFeed1: {
-    label: 'Live Video from the ISS',
+    label: 'Livestream of Earth & Space',
     enabled: true,
-    autoPlay: false,
+    autoPlay: true,
     mute: true,
     videoIdOverride: '',
   },
   IssFeed2: {
-    label: 'Live HD Views from the ISS',
+    label: 'Live Video from the ISS',
     enabled: true,
-    autoPlay: false,
+    autoPlay: true,
     mute: true,
     videoIdOverride: '',
   },


### PR DESCRIPTION
- Pulling live video from [Sen](https://www.sen.com/video/48b728ea-3e0d-4203-84d3-0a5caa2dfdfa) (https://www.youtube.com/watch?v=fO9e9jnhYK8) for the first ISS feed
- Switching second ISS feed to use the original one from NASA, getting rid of HD view (experimental, bound to be put down soon)
- Aligned toggles better in settings panel
- Default to no animating in panels on page load, added new setting to enable page load panel animation