### PR TITLE
chore(release-pr): Version bump to 2.1.1

### DIFF
--- a/.changelogs/v2.1.1.md
+++ b/.changelogs/v2.1.1.md
@@ -1,0 +1,5 @@
+
+### Patch Changes
+
+- [#117](https://github.com/SpaceDashboard/space-dashboard/pull/117) [`70aa777`](https://github.com/SpaceDashboard/space-dashboard/commit/70aa7777ca57778edde32151374a4bccb6d18f9a) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Updating release workflow to properly trigger staging deploy
+

--- a/.changeset/tasty-apes-shop.md
+++ b/.changeset/tasty-apes-shop.md
@@ -1,5 +1,0 @@
----
-'space-dashboard': patch
----
-
-Updating release workflow to properly trigger staging deploy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # space-dashboard
 
+## 2.1.1
+
+### Patch Changes
+
+- [#117](https://github.com/SpaceDashboard/space-dashboard/pull/117) [`70aa777`](https://github.com/SpaceDashboard/space-dashboard/commit/70aa7777ca57778edde32151374a4bccb6d18f9a) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Updating release workflow to properly trigger staging deploy
+
 ## 2.1.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "space-dashboard",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Collection of happenings in space",
   "author": "Caleb Dudley",
   "private": true,


### PR DESCRIPTION
Version bump: 2.1.1


### Patch Changes

- [#117](https://github.com/SpaceDashboard/space-dashboard/pull/117) [](https://github.com/SpaceDashboard/space-dashboard/commit/70aa7777ca57778edde32151374a4bccb6d18f9a) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Updating release workflow to properly trigger staging deploy