### PR TITLE
chore(release-pr): Version bump to 2.1.5

### DIFF
--- a/.changelogs/v2.1.5.md
+++ b/.changelogs/v2.1.5.md
@@ -1,0 +1,5 @@
+
+### Patch Changes
+
+- [#126](https://github.com/SpaceDashboard/space-dashboard/pull/126) [`e83a9e8`](https://github.com/SpaceDashboard/space-dashboard/commit/e83a9e82a664496f62da1754a7ddb5276cb8b497) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Fixing when sourcemaps are uploaded
+

--- a/.changeset/rich-bananas-cry.md
+++ b/.changeset/rich-bananas-cry.md
@@ -1,5 +1,0 @@
----
-'space-dashboard': patch
----
-
-Fixing when sourcemaps are uploaded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # space-dashboard
 
+## 2.1.5
+
+### Patch Changes
+
+- [#126](https://github.com/SpaceDashboard/space-dashboard/pull/126) [`e83a9e8`](https://github.com/SpaceDashboard/space-dashboard/commit/e83a9e82a664496f62da1754a7ddb5276cb8b497) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Fixing when sourcemaps are uploaded
+
 ## 2.1.4
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "space-dashboard",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Collection of happenings in space",
   "author": "Caleb Dudley",
   "private": true,


### PR DESCRIPTION
Version bump: 2.1.5


### Patch Changes

- [#126](https://github.com/SpaceDashboard/space-dashboard/pull/126) [](https://github.com/SpaceDashboard/space-dashboard/commit/e83a9e82a664496f62da1754a7ddb5276cb8b497) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Fixing when sourcemaps are uploaded