### PR TITLE
chore(release-pr): Version bump to 2.1.6

### DIFF
--- a/.changelogs/v2.1.6.md
+++ b/.changelogs/v2.1.6.md
@@ -1,0 +1,5 @@
+
+### Patch Changes
+
+- [#128](https://github.com/SpaceDashboard/space-dashboard/pull/128) [`a0d8c4f`](https://github.com/SpaceDashboard/space-dashboard/commit/a0d8c4fca074e1fd4b29c8eaa2442dbde639625f) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Fixing tooltips for touch devices, disabling background scrolling when full page modal is open, and adding scrollbar-color and scrollbar-width for supported browsers
+

--- a/.changeset/slimy-zoos-teach.md
+++ b/.changeset/slimy-zoos-teach.md
@@ -1,5 +1,0 @@
----
-'space-dashboard': patch
----
-
-Fixing tooltips for touch devices, disabling background scrolling when full page modal is open, and adding scrollbar-color and scrollbar-width for supported browsers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # space-dashboard
 
+## 2.1.6
+
+### Patch Changes
+
+- [#128](https://github.com/SpaceDashboard/space-dashboard/pull/128) [`a0d8c4f`](https://github.com/SpaceDashboard/space-dashboard/commit/a0d8c4fca074e1fd4b29c8eaa2442dbde639625f) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Fixing tooltips for touch devices, disabling background scrolling when full page modal is open, and adding scrollbar-color and scrollbar-width for supported browsers
+
 ## 2.1.5
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "space-dashboard",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Collection of happenings in space",
   "author": "Caleb Dudley",
   "private": true,


### PR DESCRIPTION
Version bump: 2.1.6


### Patch Changes

- [#128](https://github.com/SpaceDashboard/space-dashboard/pull/128) [](https://github.com/SpaceDashboard/space-dashboard/commit/a0d8c4fca074e1fd4b29c8eaa2442dbde639625f) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Fixing tooltips for touch devices, disabling background scrolling when full page modal is open, and adding scrollbar-color and scrollbar-width for supported browsers