### PR TITLE
chore(release-pr): Version bump to 2.1.8

### DIFF
--- a/.changelogs/v2.1.8.md
+++ b/.changelogs/v2.1.8.md
@@ -1,0 +1,5 @@
+
+### Patch Changes
+
+- [#136](https://github.com/SpaceDashboard/space-dashboard/pull/136) [`a78e345`](https://github.com/SpaceDashboard/space-dashboard/commit/a78e345d7c6503514cdd90246574ff574af74ee5) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Adding staging and production deploy workflows that trigger the core deploy workflow
+

--- a/.changeset/metal-towns-nail.md
+++ b/.changeset/metal-towns-nail.md
@@ -1,5 +1,0 @@
----
-'space-dashboard': patch
----
-
-Adding staging and production deploy workflows that trigger the core deploy workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # space-dashboard
 
+## 2.1.8
+
+### Patch Changes
+
+- [#136](https://github.com/SpaceDashboard/space-dashboard/pull/136) [`a78e345`](https://github.com/SpaceDashboard/space-dashboard/commit/a78e345d7c6503514cdd90246574ff574af74ee5) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Adding staging and production deploy workflows that trigger the core deploy workflow
+
 ## 2.1.7
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "space-dashboard",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "Collection of happenings in space",
   "author": "Caleb Dudley",
   "private": true,


### PR DESCRIPTION
Version bump: 2.1.8


### Patch Changes

- [#136](https://github.com/SpaceDashboard/space-dashboard/pull/136) [](https://github.com/SpaceDashboard/space-dashboard/commit/a78e345d7c6503514cdd90246574ff574af74ee5) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Adding staging and production deploy workflows that trigger the core deploy workflow