### PR TITLE
chore(release-pr): Version bump to 2.1.10

### DIFF
--- a/.changelogs/v2.1.10.md
+++ b/.changelogs/v2.1.10.md
@@ -1,0 +1,5 @@
+
+### Patch Changes
+
+- [#141](https://github.com/SpaceDashboard/space-dashboard/pull/141) [`db7357a`](https://github.com/SpaceDashboard/space-dashboard/commit/db7357a3e1f22ad1805cb6febef06e19e005b086) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Fixing staging-deploy workflow trigger in release workflow
+

--- a/.changeset/loud-streets-clean.md
+++ b/.changeset/loud-streets-clean.md
@@ -1,5 +1,0 @@
----
-'space-dashboard': patch
----
-
-Fixing staging-deploy workflow trigger in release workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # space-dashboard
 
+## 2.1.10
+
+### Patch Changes
+
+- [#141](https://github.com/SpaceDashboard/space-dashboard/pull/141) [`db7357a`](https://github.com/SpaceDashboard/space-dashboard/commit/db7357a3e1f22ad1805cb6febef06e19e005b086) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Fixing staging-deploy workflow trigger in release workflow
+
 ## 2.1.9
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "space-dashboard",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "Collection of happenings in space",
   "author": "Caleb Dudley",
   "private": true,


### PR DESCRIPTION
Version bump: 2.1.10


### Patch Changes

- [#141](https://github.com/SpaceDashboard/space-dashboard/pull/141) [](https://github.com/SpaceDashboard/space-dashboard/commit/db7357a3e1f22ad1805cb6febef06e19e005b086) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Fixing staging-deploy workflow trigger in release workflow