### PR TITLE
chore(release-pr): Version bump to 2.1.12

### DIFF
--- a/.changelogs/v2.1.12.md
+++ b/.changelogs/v2.1.12.md
@@ -1,0 +1,5 @@
+
+### Patch Changes
+
+- [#151](https://github.com/SpaceDashboard/space-dashboard/pull/151) [`46df169`](https://github.com/SpaceDashboard/space-dashboard/commit/46df169b81759331da9e41701b0d0d1653703f93) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Fixing live feed IDs and their links, as well as updating dependabot config to ignore major versions.
+

--- a/.changeset/great-geckos-cheer.md
+++ b/.changeset/great-geckos-cheer.md
@@ -1,5 +1,0 @@
----
-'space-dashboard': patch
----
-
-Fixing live feed IDs and their links, as well as updating dependabot config to ignore major versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # space-dashboard
 
+## 2.1.12
+
+### Patch Changes
+
+- [#151](https://github.com/SpaceDashboard/space-dashboard/pull/151) [`46df169`](https://github.com/SpaceDashboard/space-dashboard/commit/46df169b81759331da9e41701b0d0d1653703f93) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Fixing live feed IDs and their links, as well as updating dependabot config to ignore major versions.
+
 ## 2.1.11
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "space-dashboard",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "description": "Collection of happenings in space",
   "author": "Caleb Dudley",
   "private": true,


### PR DESCRIPTION
Version bump: 2.1.12


### Patch Changes

- [#151](https://github.com/SpaceDashboard/space-dashboard/pull/151) [](https://github.com/SpaceDashboard/space-dashboard/commit/46df169b81759331da9e41701b0d0d1653703f93) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Fixing live feed IDs and their links, as well as updating dependabot config to ignore major versions.