### PR TITLE
chore(release-pr): Version bump to 2.2.2

### DIFF
--- a/.changelogs/v2.2.2.md
+++ b/.changelogs/v2.2.2.md
@@ -1,0 +1,5 @@
+
+### Patch Changes
+
+- [#168](https://github.com/SpaceDashboard/space-dashboard/pull/168) [`b1aadc9`](https://github.com/SpaceDashboard/space-dashboard/commit/b1aadc98c7b6ff397d15932162fbbffb5a8fe409) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Fixing min-height that was accidentally set on the base ISS feed component, causing mobile views to not render correctly.
+

--- a/.changeset/cyan-animals-march.md
+++ b/.changeset/cyan-animals-march.md
@@ -1,5 +1,0 @@
----
-'space-dashboard': patch
----
-
-Fixing min-height that was accidentally set on the base ISS feed component, causing mobile views to not render correctly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # space-dashboard
 
+## 2.2.2
+
+### Patch Changes
+
+- [#168](https://github.com/SpaceDashboard/space-dashboard/pull/168) [`b1aadc9`](https://github.com/SpaceDashboard/space-dashboard/commit/b1aadc98c7b6ff397d15932162fbbffb5a8fe409) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Fixing min-height that was accidentally set on the base ISS feed component, causing mobile views to not render correctly.
+
 ## 2.2.1
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "space-dashboard",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Collection of happenings in space",
   "author": "Caleb Dudley",
   "private": true,
@@ -70,5 +70,5 @@
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"
   },
-  "packageManager": "yarn@4.9.4"
+  "packageManager": "yarn@4.10.3"
 }


### PR DESCRIPTION
Version bump: 2.2.2


### Patch Changes

- [#168](https://github.com/SpaceDashboard/space-dashboard/pull/168) [](https://github.com/SpaceDashboard/space-dashboard/commit/b1aadc98c7b6ff397d15932162fbbffb5a8fe409) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Fixing min-height that was accidentally set on the base ISS feed component, causing mobile views to not render correctly.