### PR TITLE
chore(release-pr): Version bump to 2.2.3

### DIFF
--- a/.changelogs/v2.2.3.md
+++ b/.changelogs/v2.2.3.md
@@ -1,0 +1,5 @@
+
+### Patch Changes
+
+- [#171](https://github.com/SpaceDashboard/space-dashboard/pull/171) [`6253981`](https://github.com/SpaceDashboard/space-dashboard/commit/625398121540998988e6797fbb4c9ba9a4efcd2a) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Adding workflow to add changeset for dependabot PRs
+

--- a/.changeset/soft-mammals-open.md
+++ b/.changeset/soft-mammals-open.md
@@ -1,5 +1,0 @@
----
-'space-dashboard': patch
----
-
-Adding workflow to add changeset for dependabot PRs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # space-dashboard
 
+## 2.2.3
+
+### Patch Changes
+
+- [#171](https://github.com/SpaceDashboard/space-dashboard/pull/171) [`6253981`](https://github.com/SpaceDashboard/space-dashboard/commit/625398121540998988e6797fbb4c9ba9a4efcd2a) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Adding workflow to add changeset for dependabot PRs
+
 ## 2.2.2
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "space-dashboard",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Collection of happenings in space",
   "author": "Caleb Dudley",
   "private": true,


### PR DESCRIPTION
Version bump: 2.2.3


### Patch Changes

- [#171](https://github.com/SpaceDashboard/space-dashboard/pull/171) [](https://github.com/SpaceDashboard/space-dashboard/commit/625398121540998988e6797fbb4c9ba9a4efcd2a) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Adding workflow to add changeset for dependabot PRs