### PR TITLE
chore(release-pr): Version bump to 2.2.3

### DIFF
--- a/.changelogs/v2.2.4.md
+++ b/.changelogs/v2.2.4.md
@@ -1,0 +1,5 @@
+
+### Patch Changes
+
+- [#173](https://github.com/SpaceDashboard/space-dashboard/pull/173) [`d91d1a5`](https://github.com/SpaceDashboard/space-dashboard/commit/d91d1a5ae3b2bcfc496b585ae67c84950ba30eef) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Small fix for dependabot changeset workflow
+

--- a/.changeset/early-buses-ring.md
+++ b/.changeset/early-buses-ring.md
@@ -1,5 +1,0 @@
----
-'space-dashboard': patch
----
-
-Small fix for dependabot changeset workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # space-dashboard
 
+## 2.2.4
+
+### Patch Changes
+
+- [#173](https://github.com/SpaceDashboard/space-dashboard/pull/173) [`d91d1a5`](https://github.com/SpaceDashboard/space-dashboard/commit/d91d1a5ae3b2bcfc496b585ae67c84950ba30eef) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Small fix for dependabot changeset workflow
+
 ## 2.2.3
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "space-dashboard",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Collection of happenings in space",
   "author": "Caleb Dudley",
   "private": true,


### PR DESCRIPTION
Version bump: 2.2.3


### Patch Changes

- [#171](https://github.com/SpaceDashboard/space-dashboard/pull/171) [](https://github.com/SpaceDashboard/space-dashboard/commit/625398121540998988e6797fbb4c9ba9a4efcd2a) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Adding workflow to add changeset for dependabot PRs