### PR TITLE
chore(release-pr): Version bump to 2.2.5

### DIFF
--- a/.changelogs/v2.2.5.md
+++ b/.changelogs/v2.2.5.md
@@ -1,0 +1,5 @@
+
+### Patch Changes
+
+- [#163](https://github.com/SpaceDashboard/space-dashboard/pull/163) [`0c53ca9`](https://github.com/SpaceDashboard/space-dashboard/commit/0c53ca90f150a60943f8dfccf6ed790328fe2a2e) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bump axios from 1.11.0 to 1.12.0
+

--- a/.changeset/1758729327-dependabot-changeset.md
+++ b/.changeset/1758729327-dependabot-changeset.md
@@ -1,5 +1,0 @@
----
-'space-dashboard': patch
----
-
-Bump axios from 1.11.0 to 1.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # space-dashboard
 
+## 2.2.5
+
+### Patch Changes
+
+- [#163](https://github.com/SpaceDashboard/space-dashboard/pull/163) [`0c53ca9`](https://github.com/SpaceDashboard/space-dashboard/commit/0c53ca90f150a60943f8dfccf6ed790328fe2a2e) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bump axios from 1.11.0 to 1.12.0
+
 ## 2.2.4
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "space-dashboard",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Collection of happenings in space",
   "author": "Caleb Dudley",
   "private": true,


### PR DESCRIPTION
Version bump: 2.2.5


### Patch Changes

- [#163](https://github.com/SpaceDashboard/space-dashboard/pull/163) [](https://github.com/SpaceDashboard/space-dashboard/commit/0c53ca90f150a60943f8dfccf6ed790328fe2a2e) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bump axios from 1.11.0 to 1.12.0