### PR TITLE
chore(release-pr): Version bump to 2.14.0

### DIFF
--- a/.changelogs/v2.14.0.md
+++ b/.changelogs/v2.14.0.md
@@ -1,0 +1,5 @@
+
+### Minor Changes
+
+- [#311](https://github.com/SpaceDashboard/space-dashboard/pull/311) [`bfc46bf`](https://github.com/SpaceDashboard/space-dashboard/commit/bfc46bf98fd88eb53cab5379478c434a17b9cff9) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Switching Near Earth Objects panel to the v2 JPL close-approach feed
+

--- a/.changeset/olive-moons-wonder.md
+++ b/.changeset/olive-moons-wonder.md
@@ -1,5 +1,0 @@
----
-'space-dashboard': minor
----
-
-Switching Near Earth Objects panel to the v2 JPL close-approach feed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # space-dashboard
 
+## 2.14.0
+
+### Minor Changes
+
+- [#311](https://github.com/SpaceDashboard/space-dashboard/pull/311) [`bfc46bf`](https://github.com/SpaceDashboard/space-dashboard/commit/bfc46bf98fd88eb53cab5379478c434a17b9cff9) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Switching Near Earth Objects panel to the v2 JPL close-approach feed
+
 ## 2.13.1
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "space-dashboard",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "description": "Collection of happenings in space",
   "author": "Caleb Dudley",
   "private": true,


### PR DESCRIPTION
Version bump: 2.14.0


### Minor Changes

- [#311](https://github.com/SpaceDashboard/space-dashboard/pull/311) [](https://github.com/SpaceDashboard/space-dashboard/commit/bfc46bf98fd88eb53cab5379478c434a17b9cff9) Thanks [@AstroCaleb](https://github.com/AstroCaleb)! - Switching Near Earth Objects panel to the v2 JPL close-approach feed